### PR TITLE
Don't geomax when adding a layer

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -79,7 +79,7 @@
       </div>
     <% end %>
   </div>
-  <% unless [Post::POST_TYPE_HAVE, Post::POST_TYPE_WANT].include?(@post.post_type) %>
+  <% unless [Post::POST_TYPE_HAVE, Post::POST_TYPE_WANT, Post::POST_TYPE_LAYER].include?(@post.post_type) %>
     <%= render 'geo_maxing_form_section', form: form, post: @post %>
   <% end %>
 


### PR DESCRIPTION
Test coverage:
Creating a layer does not present the option to geomax
![image](https://user-images.githubusercontent.com/8635004/153734368-7093f136-7400-493f-aa9c-f8e795d5a171.png)

Regression
Create a subject still asks to geomax
<img width="820" alt="image" src="https://user-images.githubusercontent.com/8635004/153734396-2169072b-0923-47b9-a3a2-b841225ebff0.png">

