### PR TITLE
Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ COPY Gemfile ./
 COPY Gemfile.lock ./
 
 RUN apt install shared-mime-info
+RUN gem install nokogiri -v 1.13.10
 RUN gem install mimemagic -v '0.3.10' --source 'https://rubygems.org/'
-RUN gem install rails bundler
+RUN gem install bundler -v 2.4.4
+RUN gem install rails -v 6.0.4
 RUN bundle install
 
 COPY . ./


### PR DESCRIPTION
Docker setup was broken previously. The reason was that some latest versions of dependencies no longer support the Ruby (v2.6.3) the project is currently using. Solved by using earlier versions of them which do support Ruby v2.6.3.